### PR TITLE
bug fix: wp-blog-header returns 404 in conditions of certain permlink…

### DIFF
--- a/health.php
+++ b/health.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/wp-blog-header.php' );
+require_once( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/wp-config.php' );
 
 $processes = get_option( 'elb-health-check-processes' );
 foreach ( $processes as $process ) {


### PR DESCRIPTION
…s configuration. using wp-config.php instead
